### PR TITLE
Save brazilian document in standard format

### DIFF
--- a/lib/brazilian_document_wrapper/acts_as_brazilian_document_wrapper.rb
+++ b/lib/brazilian_document_wrapper/acts_as_brazilian_document_wrapper.rb
@@ -16,6 +16,11 @@ module BrazilianDocumentWrapper
     end
 
     included do
+      before_save do
+        self[brazilian_document_field] = self[brazilian_document_field].to_brazilian_document
+                                                                       .standard
+      end
+
       def legal_person?
         send(brazilian_document_field).cnpj?
       end

--- a/test/acts_as_brazilian_document_wrapper_test.rb
+++ b/test/acts_as_brazilian_document_wrapper_test.rb
@@ -32,4 +32,12 @@ class ActsAsBrazilianDocumentWrapperTest < ActiveSupport::TestCase
     assert_equal false, protest.natural_person?
     assert_equal true, protest.legal_person?
   end
+
+  def test_a_business_protest_should_save_document_in_format_standard
+    protest = BusinessProtest.new(document: '52256591000166')
+
+    protest.save!
+
+    assert_equal protest.document, '52.256.591/0001-66'
+  end
 end


### PR DESCRIPTION
It should always save in standard format even if a user enters a stripped version of a brazilian document