### PR TITLE
Fix class to handle document when 0s are missing in the beginning of the document

### DIFF
--- a/lib/brazilian_document_wrapper/wrapper.rb
+++ b/lib/brazilian_document_wrapper/wrapper.rb
@@ -12,7 +12,7 @@ module BrazilianDocumentWrapper
       raise InvalidDocumentError if invalid_document?
 
       return_document_type do
-        BRDocuments::CNPJ.strip(self)
+        BRDocuments::CNPJ.strip(value)
       end
     end
 
@@ -21,9 +21,9 @@ module BrazilianDocumentWrapper
 
       return_document_type do
         if cpf?
-          BRDocuments::CPF.pretty(self)
+          BRDocuments::CPF.pretty(value)
         else
-          BRDocuments::CNPJ.pretty(self)
+          BRDocuments::CNPJ.pretty(value)
         end
       end
     end
@@ -31,7 +31,7 @@ module BrazilianDocumentWrapper
     def doc_type
       return 'CPF' if cpf?
 
-      return 'CNPJ' if cnpj?
+      'CNPJ' if cnpj?
     end
 
     def stripped_prefix
@@ -63,22 +63,30 @@ module BrazilianDocumentWrapper
 
     def to_param
       return_document_type do
-        BRDocuments::CNPJ.strip(self)
+        BRDocuments::CNPJ.strip(value)
       end
     end
 
     def cnpj?
-      BRDocuments::CNPJ.valid?(self)
+      BRDocuments::CNPJ.valid?(value)
     end
 
     def cpf?
-      BRDocuments::CPF.valid?(self)
+      BRDocuments::CPF.valid?(value)
     end
 
     private
 
     def return_document_type
       BrazilianDocumentWrapper::Wrapper.new(yield)
+    end
+
+    def value
+      if length > 11
+        to_s.rjust(14, '0')
+      else
+        to_s.rjust(11, '0')
+      end
     end
   end
 end

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3,6 +3,18 @@
 require 'test_helper'
 
 class WrapperTest < ActiveSupport::TestCase
+  test 'stardand to return the document when 0 is missing from the beginning of cnpj' do
+    assert_equal '04.985.802/0001-59', '4985802000159'.to_brazilian_document.standard
+  end
+
+  test 'stripped to return the document when 0 is missing from the beginning of cnpj' do
+    assert_equal '04985802000159', '4985802000159'.to_brazilian_document.stripped
+  end
+
+  test 'stardand to return the document when 0 is missing from the beginning of cpf' do
+    assert_equal '078.810.710-01', '7881071001'.to_brazilian_document.standard
+  end
+
   test 'formatted to return the document in the standard format' do
     assert_equal '77.075.203/0001-71', '77075203000171'.to_brazilian_document.standard
   end


### PR DESCRIPTION
When 0 are missing in the beginning of the document, the behaviour was to raise an error.
Fix that with rjust depending on the length of the string