### PR TITLE
Fix standard spelling in wrapper tests

### DIFF
--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class WrapperTest < ActiveSupport::TestCase
-  test 'stardand to return the document when 0 is missing from the beginning of cnpj' do
+  test 'standard to return the document when 0 is missing from the beginning of cnpj' do
     assert_equal '04.985.802/0001-59', '4985802000159'.to_brazilian_document.standard
   end
 
@@ -11,7 +11,7 @@ class WrapperTest < ActiveSupport::TestCase
     assert_equal '04985802000159', '4985802000159'.to_brazilian_document.stripped
   end
 
-  test 'stardand to return the document when 0 is missing from the beginning of cpf' do
+  test 'standard to return the document when 0 is missing from the beginning of cpf' do
     assert_equal '078.810.710-01', '7881071001'.to_brazilian_document.standard
   end
 


### PR DESCRIPTION
## Summary
- correct misspelled `stardand` in `wrapper_test.rb`

## Testing
- `bundle exec rake test` *(fails: Could not find sqlite3-1.7.3)*

------
https://chatgpt.com/codex/tasks/task_e_6846efb59868832b91e57c5e954b64ad