### PR TITLE
Fix README model setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ gem install brazilian_document_wrapper
 
 ## Usage
 
-Define attribute to acts_as_brazilian_document_wrapper:
+Define attribute to acts_as_brazilian_document:
 ```ruby
 class Customer < ApplicationRecord
   acts_as_brazilian_document brazilian_document_field: :cpf


### PR DESCRIPTION
## Summary
- fix wording for using acts_as_brazilian_document in README

## Testing
- `bundle exec rake test` *(fails: Could not find gems)*

------
https://chatgpt.com/codex/tasks/task_e_6846efaaa1f4832bb1e1f3318cc709e3