### PR TITLE
Fix doc stripping for cpf/cnpj

### DIFF
--- a/lib/brazilian_document_wrapper/wrapper.rb
+++ b/lib/brazilian_document_wrapper/wrapper.rb
@@ -12,7 +12,11 @@ module BrazilianDocumentWrapper
       raise InvalidDocumentError if invalid_document?
 
       return_document_type do
-        BRDocuments::CNPJ.strip(value)
+        if cpf?
+          BRDocuments::CPF.strip(value)
+        else
+          BRDocuments::CNPJ.strip(value)
+        end
       end
     end
 
@@ -67,7 +71,11 @@ module BrazilianDocumentWrapper
 
     def to_param
       return_document_type do
-        BRDocuments::CNPJ.strip(value)
+        if cpf?
+          BRDocuments::CPF.strip(value)
+        else
+          BRDocuments::CNPJ.strip(value)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
- fix Wrapper#stripped and #to_param to use CPF.strip when needed
- keep other behaviour unchanged

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6846efa8537c832b85e9e6319003a24d