### PR TITLE
Improve InvalidDocumentError feedback

### DIFF
--- a/lib/brazilian_document_wrapper/wrapper.rb
+++ b/lib/brazilian_document_wrapper/wrapper.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
-class InvalidDocumentError < StandardError; end
+class InvalidDocumentError < StandardError
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+    super("Invalid document: #{document}")
+  end
+end
 
 module BrazilianDocumentWrapper
   class Wrapper < String
@@ -9,7 +16,7 @@ module BrazilianDocumentWrapper
     end
 
     def stripped
-      raise InvalidDocumentError if invalid_document?
+      raise InvalidDocumentError.new(self) if invalid_document?
 
       return_document_type do
         if cpf?
@@ -21,7 +28,7 @@ module BrazilianDocumentWrapper
     end
 
     def pretty
-      raise InvalidDocumentError if invalid_document?
+      raise InvalidDocumentError.new(self) if invalid_document?
 
       return_document_type do
         if cpf?
@@ -55,7 +62,7 @@ module BrazilianDocumentWrapper
     end
 
     def headquarter
-      raise InvalidDocumentError if invalid_cnpj?
+      raise InvalidDocumentError.new(self) if invalid_cnpj?
 
       headquarter = "#{pretty_prefix}/0001"
       verify_digits = BRDocuments::CNPJ.calculate_verify_digits(headquarter).join('')

--- a/test/wrapper_test.rb
+++ b/test/wrapper_test.rb
@@ -65,9 +65,10 @@ class WrapperTest < ActiveSupport::TestCase
   end
 
   test 'to raise InvalidDocumentError when string is a invalid document' do
-    assert_raise(InvalidDocumentError) do
+    error = assert_raise(InvalidDocumentError) do
       '384.227.160-8'.to_brazilian_document.stripped
     end
+    assert_equal 'Invalid document: 384.227.160-8', error.message
   end
 
   test 'to return a Wrapper class when is a document string' do
@@ -98,8 +99,9 @@ class WrapperTest < ActiveSupport::TestCase
   end
 
   test 'to raise InvalidDocumentError when headquarter is called from a invalid CNPJ' do
-    assert_raise(InvalidDocumentError) do
+    error = assert_raise(InvalidDocumentError) do
       '384.227.160-38'.to_brazilian_document.headquarter
     end
+    assert_equal 'Invalid document: 384.227.160-38', error.message
   end
 end


### PR DESCRIPTION
## Summary
- provide details about the invalid document in `InvalidDocumentError`
- raise `InvalidDocumentError` with the offending document
- verify error message contents in tests

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_684b1fbab8ec832ba4a2ddd325387e6f