### PR TITLE
fix: resolve ambiguidade CPF/CNPJ no cpf_digits (flaky no CI da cashu)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,5 +56,17 @@ This gem cannot audit apps that consume it, but if you're migrating off
   default. Any factory/fixture that assumes a digits-only result (e.g. `.to_i`,
   numeric-column seeds, `\d{14}` assertions) needs `generate_cnpj(alphanumeric: false)`.
 
+## 0.2.1
+
+### Fixed
+- `Wrapper#cpf_digits` no longer strips letters via a blanket `\D` regex — it now removes
+  only CPF mask separators (`.`, `-`), mirroring `cnpj_chars`. This resolves an ambiguity
+  where an alphanumeric CNPJ whose embedded 11 digits happened to form a valid CPF (e.g.
+  `5C9992M9H04496`, digits `59992904496`) was misdetected as a CPF, causing
+  `pretty`/`stripped` to format it as a CPF instead of a CNPJ (~5 per million CNPJs in a
+  1M-generation fuzz test).
+- CPF strings with a stray non-mask character (e.g. a letter) now correctly fail
+  validation instead of being silently coerced into a valid-looking CPF.
+
 ## 0.1.x
 See git history.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    brazilian_document_wrapper (0.2.0)
+    brazilian_document_wrapper (0.2.1)
       rails (>= 6.1, < 8.0)
 
 GEM

--- a/lib/brazilian_document_wrapper/version.rb
+++ b/lib/brazilian_document_wrapper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrazilianDocumentWrapper
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/lib/brazilian_document_wrapper/wrapper.rb
+++ b/lib/brazilian_document_wrapper/wrapper.rb
@@ -14,6 +14,7 @@ module BrazilianDocumentWrapper
 
   class Wrapper < String
     CNPJ_MASK_CHARS = %r{[.\-/]}.freeze
+    CPF_MASK_CHARS = /[.\-]/.freeze
 
     def standard
       pretty
@@ -100,8 +101,12 @@ module BrazilianDocumentWrapper
       end
     end
 
+    # Only mask separators are stripped, never letters or unexpected symbols -
+    # a stray character must fail validation, not be silently discarded.
+    # Stripping letters here made an alphanumeric CNPJ whose digits happen to
+    # form a valid CPF ambiguous: pretty/stripped would misformat it as a CPF.
     def cpf_digits
-      value.gsub(/\D/, '')
+      value.gsub(CPF_MASK_CHARS, '')
     end
 
     # Only mask separators are stripped, never letters or unexpected symbols -

--- a/test/wrapper_alphanumeric_cnpj_test.rb
+++ b/test/wrapper_alphanumeric_cnpj_test.rb
@@ -69,4 +69,27 @@ class WrapperAlphanumericCnpjTest < ActiveSupport::TestCase
     short_alphanumeric = 'ABC34501DE35'
     refute short_alphanumeric.to_brazilian_document.cnpj?
   end
+
+  # Regression: valid alphanumeric CNPJ whose embedded digits ("59992904496")
+  # happen to form a valid CPF. cpf_digits used to strip letters with /\D/,
+  # so cpf? returned true and pretty/stripped misformatted the document as a
+  # CPF - generate_cnpj could emit CPF-shaped strings at random (flaky specs).
+  AMBIGUOUS_CNPJ = '5C9992M9H04496'
+
+  test 'an alphanumeric CNPJ whose digits form a valid CPF is never a CPF' do
+    wrapper = AMBIGUOUS_CNPJ.to_brazilian_document
+    assert_equal false, wrapper.cpf?
+    assert_equal true, wrapper.cnpj?
+    assert_equal 'CNPJ', wrapper.doc_type
+  end
+
+  test 'pretty and stripped format the ambiguous document as CNPJ' do
+    wrapper = AMBIGUOUS_CNPJ.to_brazilian_document
+    assert_equal '5C.999.2M9/H044-96', wrapper.pretty
+    assert_equal AMBIGUOUS_CNPJ, wrapper.stripped
+  end
+
+  test 'a CPF-shaped string containing letters is not silently coerced into a CPF' do
+    assert_equal false, '9A3.248.661-90'.to_brazilian_document.cpf?
+  end
 end


### PR DESCRIPTION
## Resumo
- `cpf_digits` deixou de descartar letras (`/\D/`) e agora remove apenas separadores de máscara (`.` e `-`), como o `cnpj_chars` já faz

## Objetivo
Corrigir flaky no CI da cashu: um CNPJ alfanumérico **válido** cujos 11 dígitos embutidos formam por acaso um CPF válido era despachado pelo caminho de CPF em `pretty`/`stripped`.

Exemplo real: `"5C9992M9H04496"` (CNPJ alfanumérico válido) → dígitos `"59992904496"` formam um CPF válido → `cpf?` retornava `true` → `pretty` devolvia `"599.929.044-96"`.

Como `generate_cnpj` retorna `pretty`, ele emitia strings em formato de CPF a uma taxa de **~5 por milhão** (fuzz de 1M de gerações). Nas factories da cashu isso derrubava `create(:business, cnpj: ...)` com `CNPJ precisa ser válido` — falha intermitente no CI ([exemplo](https://github.com/CashU-BR/cashu/actions/runs/29527263994)).

## Mudanças
- `Wrapper#cpf_digits`: `value.gsub(/\D/, '')` → `value.gsub(CPF_MASK_CHARS, '')` (novo `CPF_MASK_CHARS = /[.\-]/`)
- Com letras preservadas, o regex de validação do CPF (`\A\d{11}\z`) rejeita o documento e o despacho cai corretamente no caminho de CNPJ
- Segue o princípio já documentado no `cnpj_chars`: *"a stray character must fail validation, not be silently discarded"*

## Testes
- Regressão com o vetor ambíguo `5C9992M9H04496`: `cpf?` falso, `cnpj?` verdadeiro, `pretty`/`stripped` formatam como CNPJ
- CPF com letra intrusa (`9A3.248.661-90`) não é mais coagido a CPF
- Suíte completa: 75 runs, 388 assertions, 0 falhas, 100% de cobertura
- Fuzz de 1M de `generate_cnpj` + validação: **0 inválidos** (antes do fix: 5)

## Impacto / Breaking
- CPFs com máscara padrão (`973.248.661-90`) e sem máscara seguem válidos; zero-padding de colunas inteiras preservado
- **Mudança de comportamento**: CPF com caracteres estranhos (letras, espaços internos, `/`) agora **falha** a validação em vez de ser saneado silenciosamente — alinhado à filosofia do gem

## Follow-up
- Após merge, tagear `0.2.1` e bumpar a ref no Gemfile da cashu (hoje pinada em `tag: '0.2.0'`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CashU-BR/codesmith/brazilian_document_wrapper/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786822837&installation_id=131803874&pr_number=28&repository=CashU-BR%2Fbrazilian_document_wrapper&return_to=https%3A%2F%2Fgithub.com%2FCashU-BR%2Fbrazilian_document_wrapper%2Fpull%2F28&signature=3ca0a69d6a1ef0988467037c2782d794af8cfd91b18c8e52e836255d75260e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->