### PR TITLE
docs: fix CHANGELOG section for 0.2.0/0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 ## 0.2.1
 
+### Fixed
+- `Wrapper#cpf_digits` no longer strips letters via a blanket `\D` regex — it now removes
+  only CPF mask separators (`.`, `-`), mirroring `cnpj_chars`. This resolves an ambiguity
+  where an alphanumeric CNPJ whose embedded 11 digits happened to form a valid CPF (e.g.
+  `5C9992M9H04496`, digits `59992904496`) was misdetected as a CPF, causing
+  `pretty`/`stripped` to format it as a CPF instead of a CNPJ (~5 per million CNPJs in a
+  1M-generation fuzz test).
+- CPF strings with a stray non-mask character (e.g. a letter) now correctly fail
+  validation instead of being silently coerced into a valid-looking CPF.
+
+## 0.2.0
+
 ### Added
 - Support for alphanumeric CNPJ (IN RFB 2.229/2024, in production since 01/07/2026).
   `cnpj?`, `pretty`/`standard`, `stripped`/`to_param`, `headquarter`, and the new
@@ -63,18 +75,6 @@ This gem cannot audit apps that consume it, but if you're migrating off
 - `BrazilianDocumentWrapper.generate_cnpj` now returns an **alphanumeric** CNPJ by
   default. Any factory/fixture that assumes a digits-only result (e.g. `.to_i`,
   numeric-column seeds, `\d{14}` assertions) needs `generate_cnpj(alphanumeric: false)`.
-
-## 0.2.1
-
-### Fixed
-- `Wrapper#cpf_digits` no longer strips letters via a blanket `\D` regex — it now removes
-  only CPF mask separators (`.`, `-`), mirroring `cnpj_chars`. This resolves an ambiguity
-  where an alphanumeric CNPJ whose embedded 11 digits happened to form a valid CPF (e.g.
-  `5C9992M9H04496`, digits `59992904496`) was misdetected as a CPF, causing
-  `pretty`/`stripped` to format it as a CPF instead of a CNPJ (~5 per million CNPJs in a
-  1M-generation fuzz test).
-- CPF strings with a stray non-mask character (e.g. a letter) now correctly fail
-  validation instead of being silently coerced into a valid-looking CPF.
 
 ## 0.1.x
 See git history.


### PR DESCRIPTION
## Resumo
Corrige o `CHANGELOG.md`: um edit num PR anterior trocou o cabeçalho da seção `## 0.2.0` para `## 0.2.1` por engano, deixando duas seções `## 0.2.1` (uma com o conteúdo real de 0.2.0 — CNPJ alfanumérico — e outra, mais abaixo, com o conteúdo real de 0.2.1 — fix de ambiguidade CPF/CNPJ) e nenhuma seção `## 0.2.0`.

## Objetivo
Ter o CHANGELOG correto antes de gerar as releases do GitHub para 0.2.1 e 0.2.2.

## Mudanças
- Restaura `## 0.2.0` como cabeçalho do conteúdo de CNPJ alfanumérico.
- Mantém `## 0.2.1` apontando para o fix de ambiguidade CPF/CNPJ.
- Ordem final: 0.2.2 → 0.2.1 → 0.2.0 → 0.1.x.

Apenas documentação, nenhuma mudança de código.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CashU-BR/codesmith/brazilian_document_wrapper/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786885833&installation_id=131803874&pr_number=30&repository=CashU-BR%2Fbrazilian_document_wrapper&return_to=https%3A%2F%2Fgithub.com%2FCashU-BR%2Fbrazilian_document_wrapper%2Fpull%2F30&signature=ae8a1e58324a418afe76e865eebed5475ca2b9682009217b7101313441730fce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->